### PR TITLE
로깅 필터 추가 및 테스트후 API 요청 형식 에러로 인한 버그 수정, GitLab API 라이브러리 의존성 수정, 코멘트작성로직 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 	implementation 'org.springframework.ai:spring-ai-ollama-spring-boot-starter'
 
 	// GitLab API
-	implementation 'org.gitlab4j:gitlab4j-api:5.5.0'
+	implementation 'org.gitlab4j:gitlab4j-api:6.0.0-rc.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kjh/ollama/langserve/controller/ExceptionController.java
+++ b/src/main/java/com/kjh/ollama/langserve/controller/ExceptionController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.List;
 
-import static com.kjh.ollama.langserve.util.MessageUtil.*;
+import static com.kjh.ollama.langserve.util.MessageUtils.*;
 
 /**
  * 전체 컨트롤 공통 에러처리 ControllerAdvice

--- a/src/main/java/com/kjh/ollama/langserve/filter/LoggingFilter.java
+++ b/src/main/java/com/kjh/ollama/langserve/filter/LoggingFilter.java
@@ -1,0 +1,135 @@
+package com.kjh.ollama.langserve.filter;
+
+import com.kjh.ollama.langserve.filter.reqeustwrapper.CachedBodyHttpServletRequest;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.MediaType.*;
+
+/**
+ * 로깅 필터
+ */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class LoggingFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 각 요청에 대해 고유한 traceId를 생성하여 MDC에 추가
+        MDC.put("traceId", UUID.randomUUID().toString());
+        try {
+            doFilterWrapped(request, response, filterChain);
+        } finally {
+            // 필터 처리가 끝나면 MDC를 정리
+            MDC.clear();
+        }
+    }
+
+    /**
+     * 요청과 응답을 래핑하여 로깅을 수행하는 메서드
+     *
+     * @param request
+     * @param response
+     * @param filterChain
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void doFilterWrapped(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        CachedBodyHttpServletRequest requestWrapper = new CachedBodyHttpServletRequest(request);
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+        try {
+            logRequest(requestWrapper);
+            filterChain.doFilter(requestWrapper, responseWrapper);
+        } finally {
+            logResponse(responseWrapper);
+            responseWrapper.copyBodyToResponse();
+        }
+    }
+
+    /**
+     * Http 요청 정보를 로깅하는 메서드
+     *
+     * @param request
+     * @throws IOException
+     */
+    private void logRequest(HttpServletRequest request) throws IOException {
+        String queryString = request.getQueryString();
+        String prefix = "Request";
+        log.info("Request : {} uri=[{}] content-type=[{}]",
+                request.getMethod(),
+                queryString == null ? request.getRequestURI() : request.getRequestURI() + queryString,
+                request.getContentType()
+        );
+
+        if (request.getContentType() != null) {
+            if (isTextBasedContent(request.getContentType())) {
+                logPayload("Request", request.getInputStream());
+            } else {
+                logPayload("Request", request.getParameterMap());
+            }
+        }
+
+    }
+
+    /**
+     * HTTP 응답정보를 로깅하는 메서드
+     * @param response
+     * @throws IOException
+     */
+    private void logResponse(ContentCachingResponseWrapper  response) throws IOException {
+        logPayload("Response", response.getContentInputStream());
+    }
+
+    /**
+     * 입력 스트림의 내용을 로깅하는 메서드
+     */
+    private void logPayload(String prefix, InputStream inputStream) throws IOException {
+        byte[] content = StreamUtils.copyToByteArray(inputStream);
+        if (content.length > 0) {
+            String contentString = new String(content);
+            log.info("{} Payload: {}", prefix, contentString);
+        }
+    }
+    /**
+     * 파라미터 맵의 내용을 로깅하는 메서드
+     */
+    private void logPayload(String prefix, Map<String, String[]> parameter) {
+        log.info("{} Payload: {}", prefix, getParameterString(parameter));
+    }
+
+    /**
+     * 파라미터 맵을 문자열로 변환하는 메서드
+     */
+    private String getParameterString(Map<String, String[]> parameter) {
+        return parameter.entrySet().stream()
+                .map(e -> "[" + e.getKey() + " : " + String.join(", ", e.getValue()) + "]")
+                .collect(Collectors.joining(", "));
+    }
+
+
+    /**
+     * 컨텐츠 타입이 텍스트 기반인지 확인하는 메서드
+     */
+    private boolean isTextBasedContent(String contentType) {
+        return contentType.startsWith(TEXT_PLAIN_VALUE) ||
+                contentType.startsWith(APPLICATION_JSON_VALUE) ||
+                contentType.startsWith(APPLICATION_XML_VALUE);
+    }
+
+}

--- a/src/main/java/com/kjh/ollama/langserve/filter/reqeustwrapper/CachedBodyHttpServletRequest.java
+++ b/src/main/java/com/kjh/ollama/langserve/filter/reqeustwrapper/CachedBodyHttpServletRequest.java
@@ -1,0 +1,62 @@
+package com.kjh.ollama.langserve.filter.reqeustwrapper;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.springframework.util.StreamUtils;
+
+import java.io.*;
+
+/**
+ * HttpServletRequest InputStream을 여러번 읽기 위한 커스텀 HttpServletRequest
+ */
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+    private byte[] cachedBody;
+
+    public CachedBodyHttpServletRequest(HttpServletRequest request) throws IOException {
+        super(request);
+        InputStream requestInputStream = request.getInputStream();
+        this.cachedBody = StreamUtils.copyToByteArray(requestInputStream);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return new CachedBodyServletInputStream(this.cachedBody);
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(this.cachedBody);
+        return new BufferedReader(new InputStreamReader(byteArrayInputStream));
+    }
+
+    private static class CachedBodyServletInputStream extends ServletInputStream {
+        private final ByteArrayInputStream inputStream;
+
+        public CachedBodyServletInputStream(byte[] cachedBody) {
+            this.inputStream = new ByteArrayInputStream(cachedBody);
+        }
+
+        @Override
+        public boolean isFinished() {
+            return inputStream.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int read() throws IOException {
+            return inputStream.read();
+        }
+    }
+}

--- a/src/main/java/com/kjh/ollama/langserve/model/response/CustomErrorResponse.java
+++ b/src/main/java/com/kjh/ollama/langserve/model/response/CustomErrorResponse.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import java.util.HashMap;
 import java.util.Map;
 
-@Getter
 public record CustomErrorResponse(int code, String message, Map<String, String> validation) {
     @Builder
     public CustomErrorResponse(int code, String message, Map<String, String> validation) {

--- a/src/main/java/com/kjh/ollama/langserve/model/vo/GitLabProjectInfo.java
+++ b/src/main/java/com/kjh/ollama/langserve/model/vo/GitLabProjectInfo.java
@@ -1,0 +1,379 @@
+package com.kjh.ollama.langserve.model.vo;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.gitlab4j.api.Constants;
+import org.gitlab4j.api.ProjectLicense;
+import org.gitlab4j.api.models.*;
+import org.gitlab4j.api.utils.JacksonJson;
+import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
+
+@Getter
+@Setter
+public class GitLabProjectInfo implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 12L;
+
+    private Integer approvalsBeforeMerge;
+    private Boolean archived;
+    private String avatarUrl;
+    private Boolean containerRegistryEnabled;
+    private Date createdAt;
+    private Long creatorId;
+    private String defaultBranch;
+    private String description;
+
+    private Integer forksCount;
+
+    private GitLabProjectInfo forkedFromProject;
+    private String httpUrlToRepo;
+    private Long id;
+    private Boolean isPublic;
+    private Boolean issuesEnabled;
+    private Boolean jobsEnabled;
+    private Date lastActivityAt;
+    private Boolean lfsEnabled;
+    private GitLabProjectInfo.MergeMethod mergeMethod;
+    private Boolean mergeRequestsEnabled;
+    private String name;
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = String.class, name = "string"),
+            @JsonSubTypes.Type(value = Namespace.class, name = "object")
+    })
+    private Object namespace;
+    private String nameWithNamespace;
+    private Boolean onlyAllowMergeIfPipelineSucceeds;
+    private Boolean allowMergeOnSkippedPipeline;
+    private Boolean onlyAllowMergeIfAllDiscussionsAreResolved;
+    private Integer openIssuesCount;
+    private Owner owner;
+    private String path;
+    private String pathWithNamespace;
+    private Permissions permissions;
+    private Boolean publicJobs;
+    private String repositoryStorage;
+    private Boolean requestAccessEnabled;
+    private String runnersToken;
+    private Boolean sharedRunnersEnabled;
+    private List<SharedGroup> sharedWithGroups;
+    private Boolean snippetsEnabled;
+    private String sshUrlToRepo;
+    private Integer starCount;
+    private List<String> tagList;
+    private List<String> topics;
+    private Integer visibilityLevel;
+    private Visibility visibility;
+    private Boolean wallEnabled;
+    private String webUrl;
+    private Boolean wikiEnabled;
+    private Boolean printingMergeRequestLinkEnabled;
+    private Boolean resolveOutdatedDiffDiscussions;
+    private ProjectStatistics statistics;
+    private Boolean initializeWithReadme;
+    private Boolean packagesEnabled;
+    private Boolean emptyRepo;
+    private String licenseUrl;
+    private ProjectLicense license;
+    private List<CustomAttribute> customAttributes;
+    private String buildCoverageRegex;
+    private Constants.BuildGitStrategy buildGitStrategy;
+    private String readmeUrl;
+    private Boolean canCreateMergeRequestIn;
+    private ImportStatus.Status importStatus;
+    private Integer ciDefaultGitDepth;
+    private Boolean ciForwardDeploymentEnabled;
+    private String ciConfigPath;
+    private Boolean removeSourceBranchAfterMerge;
+    private Boolean autoDevopsEnabled;
+    private Constants.AutoDevopsDeployStrategy autoDevopsDeployStrategy;
+    private Boolean autocloseReferencedIssues;
+    private Boolean emailsDisabled;
+    private String suggestionCommitMessage;
+    private Constants.SquashOption squashOption;
+    private String mergeCommitTemplate;
+    private String squashCommitTemplate;
+    private String issueBranchTemplate;
+    @JsonProperty("_links")
+    private Map<String, String> links;
+    @JsonSerialize(
+            using = JacksonJson.DateOnlySerializer.class
+    )
+    private Date markedForDeletionOn;
+
+    public GitLabProjectInfo() {
+    }
+
+    public GitLabProjectInfo withApprovalsBeforeMerge(Integer approvalsBeforeMerge) {
+        this.approvalsBeforeMerge = approvalsBeforeMerge;
+        return this;
+    }
+
+    public GitLabProjectInfo withContainerRegistryEnabled(boolean containerRegistryEnabled) {
+        this.containerRegistryEnabled = containerRegistryEnabled;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withDefaultBranch(String defaultBranch) {
+        this.defaultBranch = defaultBranch;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public GitLabProjectInfo withId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public GitLabProjectInfo withIssuesEnabled(boolean issuesEnabled) {
+        this.issuesEnabled = issuesEnabled;
+        return this;
+    }
+
+    public GitLabProjectInfo withJobsEnabled(boolean jobsEnabled) {
+        this.jobsEnabled = jobsEnabled;
+        return this;
+    }
+
+    public GitLabProjectInfo withLfsEnabled(Boolean lfsEnabled) {
+        this.lfsEnabled = lfsEnabled;
+        return this;
+    }
+
+    public GitLabProjectInfo withMergeMethod(GitLabProjectInfo.MergeMethod mergeMethod) {
+        this.mergeMethod = mergeMethod;
+        return this;
+    }
+
+    public GitLabProjectInfo withMergeRequestsEnabled(boolean mergeRequestsEnabled) {
+        this.mergeRequestsEnabled = mergeRequestsEnabled;
+        return this;
+    }
+
+    public GitLabProjectInfo withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public GitLabProjectInfo withNamespace(Namespace namespace) {
+        this.namespace = namespace;
+        return this;
+    }
+
+    public GitLabProjectInfo withNamespaceId(long namespaceId) {
+        this.namespace = new Namespace();
+        Namespace namespace1 = (Namespace) namespace;
+        namespace1.setId(namespaceId);
+        return this;
+    }
+
+    public GitLabProjectInfo withOnlyAllowMergeIfPipelineSucceeds(Boolean onlyAllowMergeIfPipelineSucceeds) {
+        this.onlyAllowMergeIfPipelineSucceeds = onlyAllowMergeIfPipelineSucceeds;
+        return this;
+    }
+
+    public GitLabProjectInfo withAllowMergeOnSkippedPipeline(Boolean allowMergeOnSkippedPipeline) {
+        this.allowMergeOnSkippedPipeline = allowMergeOnSkippedPipeline;
+        return this;
+    }
+
+    public GitLabProjectInfo withOnlyAllowMergeIfAllDiscussionsAreResolved(Boolean onlyAllowMergeIfAllDiscussionsAreResolved) {
+        this.onlyAllowMergeIfAllDiscussionsAreResolved = onlyAllowMergeIfAllDiscussionsAreResolved;
+        return this;
+    }
+
+    public GitLabProjectInfo withPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+
+    public Boolean getPublic() {
+        return this.isPublic;
+    }
+
+    public void setPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+
+    public GitLabProjectInfo withPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withPublicJobs(boolean publicJobs) {
+        this.publicJobs = publicJobs;
+        return this;
+    }
+
+    public GitLabProjectInfo withRepositoryStorage(String repositoryStorage) {
+        this.repositoryStorage = repositoryStorage;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withRequestAccessEnabled(boolean requestAccessEnabled) {
+        this.requestAccessEnabled = requestAccessEnabled;
+        return this;
+    }
+
+    public GitLabProjectInfo withSharedRunnersEnabled(boolean sharedRunnersEnabled) {
+        this.sharedRunnersEnabled = sharedRunnersEnabled;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withSnippetsEnabled(boolean snippetsEnabled) {
+        this.snippetsEnabled = snippetsEnabled;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withTopics(List<String> topics) {
+        this.topics = topics;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withVisibility(Visibility visibility) {
+        this.visibility = visibility;
+        return this;
+    }
+
+    public GitLabProjectInfo withVisibilityLevel(Integer visibilityLevel) {
+        this.visibilityLevel = visibilityLevel;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withWallEnabled(Boolean wallEnabled) {
+        this.wallEnabled = wallEnabled;
+        return this;
+    }
+
+    public GitLabProjectInfo withWebUrl(String webUrl) {
+        this.webUrl = webUrl;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withWikiEnabled(boolean wikiEnabled) {
+        this.wikiEnabled = wikiEnabled;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withPrintingMergeRequestLinkEnabled(Boolean printingMergeRequestLinkEnabled) {
+        this.printingMergeRequestLinkEnabled = printingMergeRequestLinkEnabled;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withResolveOutdatedDiffDiscussions(boolean resolveOutdatedDiffDiscussions) {
+        this.resolveOutdatedDiffDiscussions = resolveOutdatedDiffDiscussions;
+        return this;
+    }
+
+    public GitLabProjectInfo withInitializeWithReadme(boolean initializeWithReadme) {
+        this.initializeWithReadme = initializeWithReadme;
+        return this;
+    }
+
+    public GitLabProjectInfo withPackagesEnabled(Boolean packagesEnabled) {
+        this.packagesEnabled = packagesEnabled;
+        return this;
+    }
+
+    public static final boolean isValid(GitLabProjectInfo project) {
+        return project != null && project.getId() != null;
+    }
+
+    public String toString() {
+        return JacksonJson.toJsonString(this);
+    }
+
+    public static final String getPathWithNammespace(String namespace, String path) {
+        String var10000 = namespace.trim();
+        return var10000 + "/" + path.trim();
+    }
+
+
+    public GitLabProjectInfo withBuildCoverageRegex(String buildCoverageRegex) {
+        this.buildCoverageRegex = buildCoverageRegex;
+        return this;
+    }
+
+    public GitLabProjectInfo withBuildGitStrategy(Constants.BuildGitStrategy buildGitStrategy) {
+        this.buildGitStrategy = buildGitStrategy;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withRemoveSourceBranchAfterMerge(Boolean removeSourceBranchAfterMerge) {
+        this.removeSourceBranchAfterMerge = removeSourceBranchAfterMerge;
+        return this;
+    }
+
+
+    public GitLabProjectInfo withEmailsDisabled(Boolean emailsDisabled) {
+        this.emailsDisabled = emailsDisabled;
+        return this;
+    }
+
+    public GitLabProjectInfo withSuggestionCommitMessage(String suggestionCommitMessage) {
+        this.suggestionCommitMessage = suggestionCommitMessage;
+        return this;
+    }
+
+    public GitLabProjectInfo withSquashOption(Constants.SquashOption squashOption) {
+        this.squashOption = squashOption;
+        return this;
+    }
+
+
+    @JsonIgnore
+    public String getLinkByName(String name) {
+        return this.links != null && !this.links.isEmpty() ? (String)this.links.get(name) : null;
+    }
+
+    public static enum MergeMethod {
+        MERGE,
+        REBASE_MERGE,
+        FF;
+
+        private static JacksonJsonEnumHelper<GitLabProjectInfo.MergeMethod> enumHelper = new JacksonJsonEnumHelper(GitLabProjectInfo.MergeMethod.class);
+
+        private MergeMethod() {
+        }
+
+        @JsonCreator
+        public static GitLabProjectInfo.MergeMethod forValue(String value) {
+            return (GitLabProjectInfo.MergeMethod)enumHelper.forValue(value);
+        }
+
+        @JsonValue
+        public String toValue() {
+            return enumHelper.toString(this);
+        }
+
+        public String toString() {
+            return enumHelper.toString(this);
+        }
+    }
+}

--- a/src/main/java/com/kjh/ollama/langserve/model/vo/GitLabWebhookEvent.java
+++ b/src/main/java/com/kjh/ollama/langserve/model/vo/GitLabWebhookEvent.java
@@ -1,6 +1,12 @@
 package com.kjh.ollama.langserve.model.vo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.gitlab4j.api.models.Project;
 
-public record GitLabWebhookEvent(String eventType, Project project, ObjectAttributes objectAttributes) {
+public record GitLabWebhookEvent(
+        @JsonProperty(value = "event_type")
+        String eventType,
+        GitLabProjectInfo project,
+        @JsonProperty(value = "object_attributes")
+        ObjectAttributes objectAttributes) {
 }

--- a/src/main/java/com/kjh/ollama/langserve/model/vo/ObjectAttributes.java
+++ b/src/main/java/com/kjh/ollama/langserve/model/vo/ObjectAttributes.java
@@ -1,6 +1,12 @@
 package com.kjh.ollama.langserve.model.vo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.gitlab4j.api.models.Commit;
 
-public record ObjectAttributes(Long iid, Commit lastCommit, String sourceBranch) {
+public record ObjectAttributes(
+        Long iid,
+        @JsonProperty("last_commit")
+        Commit lastCommit,
+        @JsonProperty("source_branch")
+        String sourceBranch) {
 }

--- a/src/main/java/com/kjh/ollama/langserve/model/vo/ReviewComment.java
+++ b/src/main/java/com/kjh/ollama/langserve/model/vo/ReviewComment.java
@@ -1,4 +1,9 @@
 package com.kjh.ollama.langserve.model.vo;
 
-public record ReviewComment(String comment, Integer lineNumber) {
+public record ReviewComment(String comment, // 리뷰 본문
+                            Integer lineNumber,// 코멘트 할 라인이 단일 라인인 경우
+                            Integer startLine, // 코멘트 할 라인이 범위인 경우 시작 라인
+                            Integer endLine // 코멘트 할 라인이 범위인 경우 종료 라인
+) {
+
 }

--- a/src/main/java/com/kjh/ollama/langserve/util/AsyncUtils.java
+++ b/src/main/java/com/kjh/ollama/langserve/util/AsyncUtils.java
@@ -1,0 +1,30 @@
+package com.kjh.ollama.langserve.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+import static com.kjh.ollama.langserve.util.MessageUtils.*;
+
+/**
+ * 비동기 처리를 위한 유틸 클래스
+ */
+@Component
+@Slf4j
+public class AsyncUtils {
+    private static final ExecutorService executor = Executors.newFixedThreadPool(10);
+
+    public static <T> void fork(Supplier<T> task) {
+        CompletableFuture.runAsync(() -> {
+            try{
+                task.get();
+            } catch (Exception e) {
+                log.error(toErrorMessageFormat(e));
+            }
+        }, executor);
+    }
+}

--- a/src/main/java/com/kjh/ollama/langserve/util/MessageUtils.java
+++ b/src/main/java/com/kjh/ollama/langserve/util/MessageUtils.java
@@ -1,6 +1,6 @@
 package com.kjh.ollama.langserve.util;
 
-public class MessageUtil {
+public class MessageUtils {
     public static String toErrorMessageFormat(Exception e) {
         return String.format(
                 "\nErrorMessage : %s\n StackTraceElement : %s", e.getMessage(), getStackTraceMsg(e.getStackTrace())

--- a/src/main/java/com/kjh/ollama/langserve/util/gitlab/PositionFactory.java
+++ b/src/main/java/com/kjh/ollama/langserve/util/gitlab/PositionFactory.java
@@ -102,4 +102,28 @@ public class PositionFactory {
                 .withStartSha(startSha)
                 .withHeadSha(headSha);
     }
+
+    /**
+     * 파일의 지정된 줄 범위에 대한 Position 객체를 생성한다.
+     * @param filePath 파일 경로
+     * @param startLine 범위의 시작 줄 번호
+     * @param endLine 범위의 끝 줄 번호
+     * @param headSha Merge Request의 최신 커밋 SHA
+     * @param isNewFile 새 파일 여부
+     * @return 지정되 줄 범위에 대한 Positon 객체
+     */
+    public static Position forLineRange(String filePath, int startLine, int endLine, String headSha, boolean isNewFile){
+        Position position = new Position()
+                .withNewPath(filePath)
+                .withNewLine(endLine) // 코멘트 할 마지막 줄
+                .withPositionType(Position.PositionType.TEXT)
+                .withHeadSha(headSha);
+
+        if(!isNewFile){
+            position.withOldPath(filePath)
+                    .withOldLine(startLine); // 코멘트 시작 줄
+        }
+
+        return position;
+    }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,37 @@
+<configuration scan="true" scanPeriod="60 seconds">
+    <property name="LOG_PATH" value="log"/>
+    <property name="LOG_FILE_NAME" value="errorLog"/>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [traceId=%X{traceId}] [%thread] [%logger{40}] - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>${LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/%d{yyyy-MM, aux}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <totalSizeCap>20GB</totalSizeCap>
+        </rollingPolicy>
+
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
- 로깅 필터 추가
- API 에서 제공하는 객체와 실제 API 요청형식이 다른 이슈가 있어 맞도록 커스텀 객체를 만듬
- GItLab API 버전이슈, Spring 3.x.x 버전이상에서는 패키지가 자카르타로 변경되므로 API 도 그에 맞춰 버전을 수정해야한다.
- 코멘트 작성 로직을 라인 단위한줄에서 범위로 코멘트를 달 수 있도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - GitLab API 의존성 버전이 6.0.0-rc.5로 업데이트되어 새로운 기능과 개선 사항이 포함될 가능성이 있습니다.
  - 코드 리뷰 프로세스에서 AI 생성 리뷰 코멘트의 시작 및 종료 라인을 더 정확하게 처리하도록 개선되었습니다.
  - HTTP 요청 및 응답 세부 정보를 기록하는 새로운 로깅 필터가 추가되었습니다.
  - 요청 본문을 여러 번 읽을 수 있도록 하는 캐시된 HTTP 요청 래퍼가 도입되었습니다.
  - GitLab 프로젝트 정보를 표현하는 새로운 데이터 모델이 추가되었습니다.

- **버그 수정**
  - 코드 리뷰 코멘트에 대한 라인 범위 지원이 추가되어 피드백의 명확성이 향상되었습니다.

- **문서화**
  - JSON 직렬화 및 역직렬화를 위한 속성 이름이 명확하게 정의되었습니다.

- **스타일**
  - 메시지 유틸리티 클래스의 이름이 명확성을 위해 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->